### PR TITLE
Added exception for new-cap rule for express.Router()

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
     ],
     rules: {
         'new-cap': [ 2, {
-            capIsNewExceptions: [ 'Polymer' ]
+            capIsNewExceptions: [ 'Polymer', 'Router' ]
         }],
         'linebreak-style': [ 2, 'unix' ],
         'indent': [ 2, 4 ],
@@ -98,3 +98,4 @@ module.exports = {
     },
     extends: 'google'
 }
+


### PR DESCRIPTION
This adds a lint exception for the `new-cap` rule for using [`Router`](https://expressjs.com/en/4x/api.html#express.router)  method without the `new` keyword.