### PR TITLE
Updating versions and new rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,8 @@ module.exports = {
     },
     env: {
         'node': true,
-        'browser': true
+        'browser': true,
+        'es6': true
     },
     extends: 'google'
 }

--- a/index.js
+++ b/index.js
@@ -83,6 +83,21 @@ module.exports = {
         // allow TODO and FIXME comments
         'no-warning-comments' : [ 0 ],
 
+        // allow usage of the `var` keyword
+        'no-var': [ 0 ],
+
+        // don't require parentheses for single argument arrow functions
+        'arrow-parens': [ 0 ],
+
+        // allow usage of `arguments` instead of only rest params (...args)
+        'prefer-rest-params': [ 0 ],
+
+        // allow the usage of `apply()` instead of only spread operator
+        'prefer-spread': [ 0 ],
+
+        // allow usage of `this` keyword outside of classes/class-like objects.
+        'no-invalid-this': [ 0 ],
+
         // allow non-radis in parseInt because ECMAScript 5
         // makes it very clear that the default is base 10.
         'radix': [ 0 ],

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/panoplyio/eslint-config-panoplioy#readme",
   "dependencies": {
-    "eslint-config-google": "0.3.0",
-    "eslint-plugin-html": "1.5.1",
+    "eslint-config-google": "0.8.0",
+    "eslint-plugin-html": "2.0.3",
     "extend": "3.0.0"
   }
 }


### PR DESCRIPTION
This PR updates the versions of 

- the base `eslint-config-google` package
- the `eslint-plugin-html` package

In addition the `es6` flag was set to true as well as adding some additional rules to be ignored by default.