### PR TITLE
Include 'backtick' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 #### Install
 
 ```
-$ npm install git://github.com/panoplyio/eslint-config-panoplyio.git#1.0.4
+$ npm install git://github.com/panoplyio/eslint-config-panoplyio.git#1.0.7
 ```
 
 > Replace `v1.0.2` with the specific tag you'd like to use for strict versioning. Or omit it for latest (not recommended)
@@ -15,6 +15,3 @@ $(npm bin)/eslint -c panoplyio --ext .html --ext .js src/
 ```
 
 This is the normal `eslint` CLI command, except preconfigured to use this `panoplyio` configuration and also scan html files.
-
-
-

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ module.exports = {
         }],
         'linebreak-style': [ 2, 'unix' ],
         'indent': [ 2, 4 ],
-        'quotes': [ 2, 'single', 'avoid-escape' ],
+        'quotes': [ 2, 'single', 'backtick', {
+            'avoidEscape': true
+        }],
 
         // spacing
         'space-in-parens': [ 0, 'always' ],
@@ -114,4 +116,3 @@ module.exports = {
     },
     extends: 'google'
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-panoplyio",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "ESLint shareable config for the Panoply JavaScript style guide",
   "main": "index.js",
   "keywords": ["eslint", "eslintconfig", "panoply", "panoply.io"],


### PR DESCRIPTION
Adds the `backtick` option to the `quotes` section.

In addition, the object property `avoid-escape` is deprecated and is replaced with `avoidEscape: true` instead.