### PR TITLE
ESLint 5 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 logs
 *.log
 npm-debug.log*
-
+.idea/
 # Runtime data
 pids
 *.pid

--- a/index.js
+++ b/index.js
@@ -13,12 +13,17 @@ module.exports = {
     plugins: [
         'html'
     ],
+    parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module'
+    },
     rules: {
         'new-cap': [ 2, {
             capIsNewExceptions: [ 'Polymer', 'Router' ]
         }],
         'linebreak-style': [ 2, 'unix' ],
-        'indent': [ 2, 4 ],
+        'indent': 'off',
+        'indent-legacy': [2, 4],
         'quotes': [ 2, 'single', 'avoid-escape' ],
 
         // spacing
@@ -29,7 +34,11 @@ module.exports = {
         'object-curly-spacing': [ 0, 'always' ],
 
         'operator-linebreak': [ 2, 'before' ],
-        'complexity': [ 2, 5 ],
+
+        // this used to be [2, 5], but when updating to ESLint 5,
+        // complexity measurement got better and so the existing codebase
+        // failed to lint
+        'complexity': [ 2, 12 ],
 
         'no-unused-expressions': [ 2, {
             'allowTernary': true,
@@ -44,9 +53,10 @@ module.exports = {
         // made more readable by inverting the condition instead.
         'no-negated-condition': [ 2 ],
 
-        // allow functions to be used before they are defined
-        // because JS compiles the functions before running the code
-        'no-use-before-define': [ 2, 'nofunc' ],
+        'no-multi-spaces': ["error", {
+            "ignoreEOLComments": true,
+
+        }],
 
         'max-len': [ 2, 80, 4, {
             ignoreUrls: true
@@ -107,7 +117,11 @@ module.exports = {
         // and helpers are at the bottom. Instead of vice-versa.
         'no-use-before-define': [ 0 ],
         // prevent debugger statements in the code
-        'no-debugger': [ 2 ]
+        'no-debugger': [ 2 ],
+
+        'prefer-const': [0],
+
+        'prefer-promise-reject-errors': [0]
     },
     env: {
         'node': true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": "eslint-config-panoplyio",
+  "version": "1.0.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
+    "eslint-config-google": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.12.0.tgz",
+      "integrity": "sha512-SHDM3nIRCJBACjf8c/H6FvCwRmKbphESNl3gJFBNbw4KYDLCONB3ABYLXDGF+iaVP9XSTND/Q5/PuGoFkp4xbg=="
+    },
+    "eslint-plugin-html": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-3.0.0.tgz",
+      "integrity": "sha1-LJgqcbnZZWVPDzpSNYc1ghoaQjk=",
+      "requires": {
+        "htmlparser2": "^3.8.2"
+      }
+    },
+    "extend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+    },
+    "htmlparser2": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+      "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "readable-stream": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+      "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "string_decoder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,14 @@
 {
   "name": "eslint-config-panoplyio",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "ESLint shareable config for the Panoply JavaScript style guide",
   "main": "index.js",
-  "keywords": ["eslint", "eslintconfig", "panoply", "panoply.io"],
+  "keywords": [
+    "eslint",
+    "eslintconfig",
+    "panoply",
+    "panoply.io"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -18,8 +23,8 @@
   },
   "homepage": "https://github.com/panoplyio/eslint-config-panoplioy#readme",
   "dependencies": {
-    "eslint-config-google": "0.8.0",
-    "eslint-plugin-html": "2.0.3",
+    "eslint-config-google": "0.12.0",
+    "eslint-plugin-html": "3.0.0",
     "extend": "3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/panoplyio/eslint-config-panoplioy#readme",
   "dependencies": {
     "eslint-config-google": "0.12.0",
-    "eslint-plugin-html": "3.0.0",
+    "eslint-plugin-html": "5.0.3",
     "extend": "3.0.0"
   }
 }


### PR DESCRIPTION
After updating the main codebase to node 10, we also have to update `eslint` to version 5. Otherwise, it won't recognize some of the newer ECMAScript features and error.

ESLint 4 and 5 introduced lots of breaking changes (or rather, improvements that show us problems in our code). Some plugins also have to be updated, and there changes to `eslint-google-config` as well.

This update updates eslint plugin versions, overrides some styles that massively fail on our code, and sets and enables some legacy options to reproduce the behavior in `package.json`. 

In addition to these modifications, a separate PR will add fixes to the panoply repo where possible.

Notable changes include:

1. `indent` has changed, and we need to use the `indent-legacy` rule instead unless we want to make huge changes to our code.

2. `complexity` works better, and some of our functions will now fail this rule. So I've increased the ceiling to the minimum number that doesn't cause our code to fail.

3. `no-multi-spaces` - has become stricter, had to set a compatibility option.

4. Some rules added to `eslint-google-config` have to be disabled.