### PR TITLE
Add the eqeqeq exception for comparing with null

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = {
         }],
 
         // disallow weak equal signs (= instead of ==)
-        'eqeqeq': [ 2 ],
+        'eqeqeq': ["error", "always", { "null": "ignore" }],
 
         // jsdoc is required but doesn't have to be valid
         // this is in order to enforce some comments on classes and method


### PR DESCRIPTION
As previously discussed, I would like to propose making an exception to our eqeqeq rule for null comparisons.

When comparing a value to `null` using `foo == null` we cover both `undefined` and `null` values,  which for the vast majority of cases makes very little difference.

This in turn would allow us to prevent naive `null` and `undefined` checks such as:

```
if (!foo) {
  // do something here
}
```

The following list of patterns (not exhausive) can be replaced with null comparisons without a change in semantics (besides the change in syntax):

```
// Before:
if (typeof foo === 'undefined') {...}
// After:
if (foo == null) {...}

// Before:
if (aNonBooleanFoo) {...} // or
if ('foo' in obj) {...} // or
if (obj.foo) {...} // or
if (Object.hasOwnProperty('foo')) {...} // for POJOs
// After:
if (!(foo == null)) {...} // checks for both null and undefined
// Which is not the same as:
if (foo != null) {...} // checks just for null and should stay banned
```

Live long and propsper,
Lior
