### PR TITLE
Comma dangle rule for multiline

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = {
         'semi': [ 0 ],
 
         // we don't care about IE8, trailing commas are valid in ES5
-        'comma-dangle': [ 0 ],
+        'comma-dangle': ["error", "always-multiline"],
 
         // allow spacing around semi-colons
         // used for spacing for-loops for readability
@@ -130,4 +130,3 @@ module.exports = {
     },
     extends: 'google'
 }
-

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = {
         // semi-colons not required (standardjs.com)
         'semi': [ 0 ],
 
-        // we don't care about IE8, trailing commas are valid in ES5
+        // trailing commas are required
         'comma-dangle': ["error", "always-multiline"],
 
         // allow spacing around semi-colons


### PR DESCRIPTION
## Description
This PR will add rule for `comma-dangle`, and trailing comma for objects & arrays will be required. Currently there 11 places in `panoply` repo that need to be fixed if the version will be implemented.

## Example for this rule. (Comma after element3)
``` js
const exampleArray = [
    'element1',
    'element2',
    'element3',
];
