### PR TITLE
[PAN-2090] ESLint — Move the "operator-linebreak" rule to common rules

### DIFF
--- a/common.js
+++ b/common.js
@@ -44,6 +44,7 @@ module.exports = {
         'eol-last': ['error', 'always'],
         'func-call-spacing': ['error', 'never'],
         'implicit-arrow-linebreak': ['error', 'beside'],
+        'operator-linebreak': ['error', 'before'],
         'indent': ['error', 4, {
             SwitchCase: 1,
             ignoredNodes: ['TemplateLiteral *'],

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ module.exports = {
         // spacing
         'computed-property-spacing': ['error', 'never'],
 
-        'operator-linebreak': ['error', 'before'],
-
         'no-unused-expressions': ['error', {
             allowTernary: true,
             allowShortCircuit: true,


### PR DESCRIPTION
Jira Task: https://panoply.atlassian.net/browse/PAN-2090

## Description
The `operator-linebreak` is relevant to all projects. Moving it to the common rules.

## Related PRs
- https://github.com/panoplyio/eslint-config-panoplyio/pull/12